### PR TITLE
use more forgiving number parsing due to cpu freq issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11 AS BUILD
+FROM golang:1.15 AS BUILD
 
 LABEL maintainer="Roman Tkalenko"
 

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -40,3 +40,25 @@ func TestScrape(t *testing.T) {
 		}
 	})
 }
+
+func TestParseNumber(t *testing.T) {
+	type testCase struct {
+		in  string
+		out int
+	}
+
+	testCases := []testCase{
+		{in: "1", out: 1},
+		{in: "1.1", out: 1},
+	}
+
+	for _, tc := range testCases {
+		out, err := parseNumber(tc.in)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if out != tc.out {
+			t.Fatalf("wrong output: %d, expected %d", out, tc.out)
+		}
+	}
+}


### PR DESCRIPTION
Encountered the following error:
```
time="2021-02-24T14:13:02Z" level=info msg="Error scraping clickhouse: Error scraping clickhouse url http://10.224.174.132:8123?query=select+metric%2C+value+from+system.asynchronous_metrics: strconv.Atoi: parsing \"2294.394\": invalid syntax" file=exporter.go line=292
```
due to fractional CPU frequency:
```
SELECT *
FROM system.asynchronous_metrics

┌─metric───────────────────────────────────┬───────value─┐
│ CPUFrequencyMHz_0                        │    2294.394 │
...
```