### PR TITLE
fix a bug -  Error scraping system.asynchronous_metrics

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -43,7 +43,7 @@ func NewExporter(uri url.URL, insecure bool, user, password string) *Exporter {
 	metricsURI.RawQuery = q.Encode()
 
 	asyncMetricsURI := uri
-	q.Set("query", "select metric, value from system.asynchronous_metrics")
+	q.Set("query", "select metric, toInt64(value) from system.asynchronous_metrics")
 	asyncMetricsURI.RawQuery = q.Encode()
 
 	eventsURI := uri


### PR DESCRIPTION
Error scraping clickhouse: Error scraping clickhouse url http://localhost:8123/?query=select+metric%2C+value+from+system.asynchronous_metrics: strconv.Atoi: parsing \"1198.727\": invalid syntax" file=exporter.go line=292