### PR TITLE
Fixed error in metric name containe hypfen '-'

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -38,11 +38,11 @@ type Exporter struct {
 func NewExporter(uri url.URL, insecure bool, user, password string) *Exporter {
 	q := uri.Query()
 	metricsURI := uri
-	q.Set("query", "select metric, toInt64(value) from system.metrics")
+	q.Set("query", "select metric, value from system.metrics")
 	metricsURI.RawQuery = q.Encode()
 
 	asyncMetricsURI := uri
-	q.Set("query", "select replaceRegexpOne(toString(metric), '-', '_') AS metric, toInt64(value) from system.asynchronous_metrics")
+	q.Set("query", "select replaceRegexpOne(toString(metric), '-', '_') AS metric, value from system.asynchronous_metrics")
 	asyncMetricsURI.RawQuery = q.Encode()
 
 	eventsURI := uri

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -38,11 +38,11 @@ type Exporter struct {
 func NewExporter(uri url.URL, insecure bool, user, password string) *Exporter {
 	q := uri.Query()
 	metricsURI := uri
-	q.Set("query", "select metric, value from system.metrics")
+	q.Set("query", "select metric, toInt64(value) from system.metrics")
 	metricsURI.RawQuery = q.Encode()
 
 	asyncMetricsURI := uri
-	q.Set("query", "select metric, value from system.asynchronous_metrics")
+	q.Set("query", "select replaceRegexpOne(toString(metric), '-', '_') AS metric, toInt64(value) from system.asynchronous_metrics")
 	asyncMetricsURI.RawQuery = q.Encode()
 
 	eventsURI := uri


### PR DESCRIPTION
In the new version of Clickhouse, the exporter does not start with the error:

```
clickhouse_exporter[51613]: panic: descriptor Desc{fqName: "clickhouse_block_queue_time_dm-2", help: "Number of BlockQueueTime_dm-2 async processed", constLabels: {}, variableLabels: []} is invalid: "clickhouse_block_queue_time_dm-2" is not a valid metric name
clickhouse_exporter[51613]: goroutine 1 [running]:
clickhouse_exporter[51613]: github.com/prometheus/client_golang/prometheus.(*Registry).MustRegister(0xc000112540, 0xc00019c0c0, 0x1, 0x1)
clickhouse_exporter[51613]:         /home/mnt-noc/clickhouse_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:404 +0xad
clickhouse_exporter[51613]: github.com/prometheus/client_golang/prometheus.MustRegister(...)
clickhouse_exporter[51613]:         /home/mnt-noc/clickhouse_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:152
clickhouse_exporter[51613]: main.main()
clickhouse_exporter[51613]:         /home/mnt-noc/clickhouse_exporter/clickhouse_exporter.go:32 +0x211

```