### PR TITLE
set non-root user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,5 @@ RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 ENTRYPOINT ["/usr/local/bin/clickhouse_exporter"]
 CMD ["-scrape_uri=http://localhost:8123"]
+USER   nobody
 EXPOSE 9116


### PR DESCRIPTION
for security, We should't need root to run. which like https://github.com/prometheus/mysqld_exporter/blob/main/Dockerfile#L11C1-L11C19
@Slach PTAL