### PR TITLE
feat: add label disk_name for table metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS BUILDER
+FROM golang:1.24 AS BUILDER
 
 LABEL maintainer="Eugene Klimov <bloodjazman@gmail.com>"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ClickHouse/clickhouse_exporter
 
-go 1.23
+go 1.24
 
 require (
 	github.com/prometheus/client_golang v1.20.5


### PR DESCRIPTION
Added label disk_name for table metrics #93.
Useful with tiered storage.
Bumped golang version to 1.24 since it doesn't even build on 1.23 even before my changes